### PR TITLE
Address issues with serializing nested structures and deserializing lists

### DIFF
--- a/go_gen/codegen.py
+++ b/go_gen/codegen.py
@@ -80,6 +80,8 @@ def build_ofclasses(version):
     for ofclass in loxi_globals.ir[version].classes:
         module_name, ofclass.goname = generate_goname(ofclass)
         ofclass.field_lengths = {}
+        ofclass.align = int(ofclass.params['align']) if 'align' in ofclass.params else 0
+        ofclass.length_includes_align = ofclass.params['length_includes_align'] == 'True' if 'length_includes_align' in ofclass.params else False
         modules[module_name].append(ofclass)
         offset = 0
         for i, m in enumerate(ofclass.members):

--- a/go_gen/templates/_decode_list.go
+++ b/go_gen/templates/_decode_list.go
@@ -36,7 +36,8 @@
 :: elem_type = util.go_ident(loxi_utils.oftype_list_elem(member.oftype))
 
 :: if member.name in ofclass.field_lengths:
-	for i := 0; i < int(${self_name}.${ofclass.field_lengths[member.name].goname}); i++ {
+    end := decoder.Offset() + int(${self_name}.${ofclass.field_lengths[member.name].goname})
+	for decoder.Offset() < end {
 :: else:
 	for decoder.Length() >= ${elem_length} {
 :: #endif

--- a/go_gen/templates/encoder.go
+++ b/go_gen/templates/encoder.go
@@ -84,8 +84,3 @@ func (e *Encoder) Write(b []byte) {
 func (e *Encoder) Bytes() []byte {
 	return e.buffer.Bytes()
 }
-
-func (e *Encoder) SkipAlign() {
-	length := len(e.buffer.Bytes())
-	e.Write(bytes.Repeat([]byte{0}, (length+7)/8*8 - length))
-}


### PR DESCRIPTION
The generated code to serialize nested structures was not handling length fields correctly. Each nested struct's Serialize method was passed an Encoder that contains a ByteBuffer representing the entire message, however the serializer code was acting as though the Encoder only contained the specific part of the message the struct was responsible for. This meant when it went to calculate and set the length fields it would set them in the wrong place in the ByteBuffer. 

For example, the length field for `FlowStatsEntry` is located as the first field in the `FlowStatsEntry` struct, so the `FlowStatsEntry.Serialize` method was using the following code to set the length:
 `binary.BigEndian.PutUint16(encoder.Bytes()[0:2], uint16(len(encoder.Bytes())))`

However `encoder.Bytes()` represents the entire OF message (which can contain multiple `FlowStatsEntry` structs) so this code is actually overwriting fields in the `Header` struct which is at the start of the ByteBuffer.

I have addressed this by following the example in the Java code generator for how to calculate and set the length fields.

Also there was an issue in `go_gen/templates/_decode_list.go` where the length field was not properly taken into account when deserializing lists, and I've addressed this.